### PR TITLE
The correct CV bandwidth selection procedure incorporating weights

### DIFF
--- a/R/causalgps_smooth.R
+++ b/R/causalgps_smooth.R
@@ -28,7 +28,7 @@ generate_kernel <- function(t) {
 #' return value (TODO)
 #' @keywords internal
 #'
-w_fun <- function(bw, matched_w, w_vals){
+w_fun <- function(bw, matched_w, matched_cw, w_vals){
     w_avals <- NULL
     for (w_val in w_vals) {
     w_std <- (matched_w - w_val) / bw

--- a/R/causalgps_smooth.R
+++ b/R/causalgps_smooth.R
@@ -31,11 +31,11 @@ generate_kernel <- function(t) {
 w_fun <- function(bw, matched_w, w_vals){
     w_avals <- NULL
     for (w_val in w_vals) {
-      w_std <- (matched_w - w_val) / bw
-      kern_std <- generate_kernel(w_std) / bw
-      tmp_mean <- mean(w_std ^ 2 * kern_std)
-      w_avals <- c(w_avals, tmp_mean * (generate_kernel(0) / bw) /
-                   (mean(kern_std) * tmp_mean - mean(w_std * kern_std) ^ 2))
+    w_std <- (matched_w - w_val) / bw
+    kern_std <- generate_kernel(w_std) / bw
+    tmp_mean <- weighted.mean(w_std ^ 2 * kern_std, w = matched_cw)
+    w_avals <- c(w_avals, tmp_mean * (generate_kernel(0) / bw) /
+                   (weighted.mean(kern_std, w = matched_cw) * tmp_mean - weighted.mean(w_std * kern_std, w = matched_cw) ^ 2))
   }
-  return(w_avals / length(matched_w))
+  return(w_avals / sum(matched_cw))
 }

--- a/R/compute_risk.R
+++ b/R/compute_risk.R
@@ -17,7 +17,7 @@
 #' @keywords internal
 #'
 compute_risk <- function(h, matched_Y, matched_w, matched_cw, w_vals) {
-  hats <- estimate_hat_vals(h, matched_w, w_vals)
+  hats <- estimate_hat_vals(h, matched_w, matched_cw, w_vals)
   tmp_mean <- mean(((matched_Y - smooth_erf(
                                     matched_Y,
                                     bw = h,

--- a/R/compute_risk.R
+++ b/R/compute_risk.R
@@ -18,10 +18,10 @@
 #'
 compute_risk <- function(h, matched_Y, matched_w, matched_cw, w_vals) {
   hats <- estimate_hat_vals(h, matched_w, matched_cw, w_vals)
-  tmp_mean <- mean(((matched_Y - smooth_erf(
+  tmp_mean <- weighted.mean(((matched_Y - smooth_erf(
                                     matched_Y,
                                     bw = h,
                                     matched_w = matched_w,
-                                    matched_cw = matched_cw)) / (1 - hats)) ^ 2)
+                                    matched_cw = matched_cw)) / (1 - hats)) ^ 2, w = matched_cw)
   return(tmp_mean)
 }

--- a/R/estimate_hat_vals.R
+++ b/R/estimate_hat_vals.R
@@ -13,9 +13,9 @@
 #' Returns fitted values, or the prediction made by the model for each observation.
 #' @keywords internal
 #'
-estimate_hat_vals <- function(bw, matched_w, w_vals) {
+estimate_hat_vals <- function(bw, matched_w, matched_cw, w_vals) {
   stats::approx(w_vals,
-                w_fun(bw, matched_w, w_vals),
+                w_fun(bw, matched_w, matched_cw, w_vals),
                 xout = matched_w,
                 rule=2)$y
 }


### PR DESCRIPTION
The cross-validation on counter_weights data needs to take weights into account. @jennyjyounglee could you also review the following changes?